### PR TITLE
Add i18n + German translation

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,16 @@
+{
+	"popupTitle": {
+		"message": "Suchmaschinen ersetzen",
+		"description": "Title of the addon's popup"
+	},
+	
+	"sourceCodeAvailable": {
+		"message": "Der Quellcode ist verfügbar auf",
+		"description": "The source code is available on GitHub"
+	},
+	
+	"version": {
+		"message": "Version",
+		"description": "the addon's version"
+	}
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,16 @@
+{
+	"popupTitle": {
+		"message": "Search Engine Redirects",
+		"description": "Title of the addon's popup"
+	},
+	
+	"sourceCodeAvailable": {
+		"message": "Source code available on",
+		"description": "The source code is available on GitHub"
+	},
+	
+	"version": {
+		"message": "Version",
+		"description": "the addon's version"
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -29,5 +29,6 @@
     "gecko": {
       "id": "{8f89fba2-6bc8-4ec4-bd09-a65639992ec4}"
     }
-  }
+  },
+  "default_locale": "en"
 }

--- a/popup.html
+++ b/popup.html
@@ -128,7 +128,7 @@
     </div>
     <section class="settings-block">
       <div>
-        <p class="settings-title">Search Engine Redirects</p>
+        <p class="settings-title"><i18n>popupTitle</i18n></p>
         <p id="demo"></p>
       </div>
       <label class="switch">
@@ -144,13 +144,13 @@
     <a class="button" id="more-options"></a>
     <div id="source-code">
       <p>
-        Source code available on
+        <i18n>sourceCodeAvailable</i18n>
         <a
           href="https://github.com/bluelockorg/Blue-Privacy-Extension"
           target="_blank"
         >
           GitHub</a
-        >. Version:&nbsp;<span id="version"></span>
+        >. <i18n>version</i18n>:&nbsp;<span id="version"></span>
       </p>
     </div>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -2,7 +2,7 @@ var translate = document.getElementsByTagName('i18n');
 
 for (var i = 0; i < translate.length; i++) {
 	var msg = translate[i].innerText;
-	translate[i].innerText = browser.i18n.getMessage(msg);
+	translate[i].innerText = chrome.i18n.getMessage(msg);
 }
 
 let disableSearchEngine = document.querySelector("#disable-searchEngine");

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,10 @@
+var translate = document.getElementsByTagName('i18n');
+
+for (var i = 0; i < translate.length; i++) {
+	var msg = translate[i].innerText;
+	translate[i].innerText = browser.i18n.getMessage(msg);
+}
+
 let disableSearchEngine = document.querySelector("#disable-searchEngine");
 
 window.browser = window.browser || window.chrome;


### PR DESCRIPTION
I added internationalization and a German translation. This works as follows: Everywhere in the popup the strings to be translated are replaced with ```<i18n>*title of the message*</i18n>```. A ```for``` loop iterates through all ```<i18n>``` elements replacing their ```innerText``` with the translation message.

Example: Instead of ```Search Engine Redirects``` there's now ```<i18n>popupTitle</i18n>```.

Btw: I love your addon already ☺️